### PR TITLE
Add format_ext_mode()

### DIFF
--- a/dircolors/pyls/pyls.py
+++ b/dircolors/pyls/pyls.py
@@ -29,9 +29,9 @@ def main():
                 if f != '.' and len(files) > 1:
                     print(dc.format(f) + ':')
                 for ff in sorted(os.listdir(f)):
-                    print(dc.format(ff, f, show_target=True))
+                    print(dc.format(ff, f, show_target=True, quote=True))
                 print()
             else:
-                print(dc.format(f, show_target=True))
+                print(dc.format(f, show_target=True, quote=True))
         except OSError as e:
             print('%s: error: %s'%(f, e), file=sys.stderr)


### PR DESCRIPTION
Add format_ext_mode()
    
Allows formatting an arbitrary string and manually passing the extension
    
```python
dc.format_ext_mode(shlex.quote('a b.png'), '.png', 0o644)
```
    
This is required to format escaped filenames, as is possible in ls:
    
```
mic@mic /tmp $ touch 'a b.png'
mic@mic /tmp $ ls a*
'a b.png'
```

`ls` highlights this correctly as a `.png` file despite the quotes that obfuscate the extension.
    
Example invocation:
    
In addition, I have added a new optional argument `quote` to `format()`;
if set to `True`, format() automatically quotes the file name using `shlex.quote()`.